### PR TITLE
added error handling for user updates

### DIFF
--- a/web-server/app.js
+++ b/web-server/app.js
@@ -63,9 +63,16 @@ app.get('/users/:id', async (req, res) => {
     }
 })
 
-
 // this updates users files
 app.patch('/users/:id', async (req, res) => {
+    const updates = Object.keys(req.body)
+    const allowedUpdates = ['name', 'email', 'password', 'age']
+    const isValidOperation = updates.every((update) => allowedUpdates.includes(update))
+
+    if (!isValidOperation) {
+        return res.status(400).send({ error: 'invalid updates' })
+    }
+
     try {
         const user = await User.findByIdAndUpdate(req.params.id, req.body, { new: true, runValidators: true })
         if (!user) {


### PR DESCRIPTION
user update PATCH calls must now contain name, email, password, and age. If the user is missing a parameter, age for example, then the call will need to contain "age": "" or you will receive an  error. probably.